### PR TITLE
use buffer-file-name to filter buffer list

### DIFF
--- a/helm-css-scss.el
+++ b/helm-css-scss.el
@@ -730,12 +730,13 @@ If $noexcursion is not-nil cursor doesn't move."
 
 (defun helm-css-scss--get-buffer-list ()
   "Get all CSS/SCSS/LESS buffers currently open"
-  (let ($buflist1)
+  (let ($buflist1 $file)
     (mapc (lambda ($buf)
-            (setq $buf (buffer-name $buf))
-            (unless (string-match "^\\s-" $buf)
-              (if (string-match "\\.\\(s?css\\|less\\)$" $buf)
-                  (setq $buflist1 (cons $buf $buflist1)))))
+            (setq $file (buffer-file-name $buf))
+            (and $file
+                 (not (string-match "^\\s-" $file))
+                 (string-match "\\.\\(s?css\\|less\\)$" $file)
+                 (setq $buflist1 (cons (buffer-name $buf) $buflist1))))
           (buffer-list))
     $buflist1))
 


### PR DESCRIPTION
This makes the function compatible with certain uniquify-buffer-name configurations.. 
An example file name might be "layout.scss • Resources/static/shared".
I don't know if there might be a reason to not match against the buffer-file-name, I can change the code to check for both if you want to.

One thing I dont understand about the code is why a buffer name should not start with s- and if that should be checked against the buffer-name instead of buffer-file-name.
