### PR TITLE
Fix package-lint/check-doc/byte-compiler warnings

### DIFF
--- a/helm-css-scss.el
+++ b/helm-css-scss.el
@@ -6,8 +6,8 @@
 ;; Author: Shingo Fukuyama - http://fukuyama.co
 ;; URL: https://github.com/ShingoFukuyama/helm-css-scss
 ;; Created: Oct 18 2013
-;; Keywords: scss css less selector helm
-;; Package-Requires: ((helm "1.0") (emacs "24"))
+;; Keywords: convenience scss css less selector helm
+;; Package-Requires: ((emacs "24.3") (helm "1.0"))
 
 ;; This program is free software; you can redistribute it and/or
 ;; modify it under the terms of the GNU General Public License as
@@ -34,7 +34,7 @@
 ;; (setq helm-css-scss-insert-close-comment-depth 2)
 ;; ;; If this value is t, split window appears inside the current window
 ;; (setq helm-css-scss-split-with-multiple-windows nil)
-;; ;; Split direction. 'split-window-vertically or 'split-window-horizontally
+;; ;; Split direction.  'split-window-vertically or 'split-window-horizontally
 ;; (setq helm-css-scss-split-direction 'split-window-vertically)
 
 ;; ;; Set local keybind map for css-mode / scss-mode
@@ -55,7 +55,7 @@
 
 ;; (helm-css-scss-insert-close-comment &optional $depth)
 ;;   Insert inline comment like " //__ comment" at the next of
-;;   a close brace "}". If it's aleardy there, update it.
+;;   a close brace "}".  If it's aleardy there, update it.
 ;;   You can also specify a nest $depth of selector.
 ;;
 
@@ -72,23 +72,23 @@
 ;;; config -----------------------------
 
 (defcustom helm-css-scss-insert-close-comment-depth 3
-  "Set SCSS style nest depth"
+  "Set SCSS style nest depth."
   :group 'helm-css-scss
   :type 'number)
 
 (defcustom helm-css-scss-split-with-multiple-windows nil
- "Split window when having multiple windows open"
- :group 'helm-css-scss
- :type 'boolean)
+  "Split window when having multiple windows open."
+  :group 'helm-css-scss
+  :type 'boolean)
 
 (defcustom helm-css-scss-split-direction 'split-window-vertically
- "Split direction"
- :type '(choice (const :tag "vertically"   split-window-vertically)
-                (const :tag "horizontally" split-window-horizontally))
- :group 'helm-css-scss)
+  "Split direction."
+  :type '(choice (const :tag "vertically"   split-window-vertically)
+                 (const :tag "horizontally" split-window-horizontally))
+  :group 'helm-css-scss)
 
 (defcustom helm-css-scss-include-commented-selector t
-  "Don't list selectors which is commented, if this value is nil"
+  "Don't list selectors which is commented, if this value is nil."
   :group 'helm-css-scss
   :type 'boolean)
 
@@ -146,7 +146,7 @@
         (funcall helm-css-scss-split-direction)))
     (other-window 1)
     (switch-to-buffer $buf))
-  "Change the way to split window only when `helm-css-scss' is calling")
+  "Change the way to split window only when `helm-css-scss' is calling.")
 
 ;; Avoide compile error for apply buffer local variable
 (defvar helm-css-scss-cache)
@@ -154,7 +154,7 @@
 (defvar helm-css-scss-last-query)
 
 (defvar helm-css-scss-overlay nil
-  "Store overlay object")
+  "Store overlay object.")
 
 (defvar helm-css-scss-buffer "*Helm Css SCSS*")
 (defvar helm-css-scss-multi-buffer "*Helm Css SCSS multi buffers*")
@@ -168,39 +168,42 @@
 ;;; common parts -----------------------------
 
 (defun helm-css-scss--target-overlay-move (&optional $beg $end $buf)
-  "Move target overlay"
+  "Move target overlay."
   (move-overlay helm-css-scss-overlay (or $beg (point-at-bol)) (or $end (point)) $buf)
   (helm-css-scss--unveil-invisible-overlay))
 
 (defun helm-css-scss-nthcar ($i $l)
-  "Return n($i) of values from the head of a list($l)"
+  "Return n($i) of values from the head of a list($l)."
   (loop for $k from 1 to $i
         collect (nth (- $k 1) $l) into $res
         finally return (delq nil $res)))
 
 (defun helm-css-scss-substruct-last-string ($text $key)
-  "Return the tail of $text without $key strings"
+  "Return the tail of $text without $key strings."
   (while (string-match $key $text)
-      (setq $text (substring $text (1+ (string-match $key $text)))))
+    (setq $text (substring $text (1+ (string-match $key $text)))))
   $text)
 
 (defsubst helm-css-scss--trim-whitespace ($str)
-  "Return string without whitespace at the both beginning and end"
+  "Return string without whitespace at the both beginning and end."
   (if (string-match "\\`\\(?:\\s-+\\)?\\(.+?\\)\\(?:\\s-+\\)?\\'" $str)
       (match-string 1 $str)
     $str))
 
 (defsubst helm-css-scss--goto-line ($line)
+  "Go to line considering narrowing."
   (goto-char (point-min))
   (forward-line (1- $line)))
 
 (defun helm-css-scss-delete-all-matches-in-buffer ($regexp)
+  "Delete all matches in buffer."
   (save-excursion
     (goto-char (point-min))
     (while (re-search-forward $regexp nil t)
       (delete-region (match-beginning 0) (match-end 0)))))
 
 (defun helm-css-scss--restore-unveiled-overlay ()
+  "Restore univeiled overlay."
   (when helm-css-scss-invisible-targets
     (mapc (lambda ($ov) (overlay-put (car $ov) 'invisible (cdr $ov)))
           helm-css-scss-invisible-targets)
@@ -220,10 +223,11 @@ This function needs to call after latest helm-css-scss-overlay set."
                      (overlay-end helm-css-scss-overlay))))
 
 (defsubst helm-css-scss--recenter ()
+  "Recenter."
   (recenter (/ (window-height) 2)))
 
 (defun helm-css-scss--nearest-line ($target $list)
-  "Return the nearest number of $target out of $list."
+  "Return the nearest number of $TARGET out of $LIST."
   (when (and $target $list)
     (let ($result)
       (cl-labels
@@ -253,6 +257,7 @@ This function needs to call after latest helm-css-scss-overlay set."
       $result)))
 
 (defun helm-css-scss--keep-nearest-position ()
+  "Keep nearest position."
   (with-helm-window
     (let (($p (point-min)) $list $bound
           $nearest-line $target-point
@@ -286,11 +291,12 @@ This function needs to call after latest helm-css-scss-overlay set."
 ;;; scan selector -----------------------------
 
 (defun helm-css-scss-comment-p (&optional $pos)
+  "Return non-nil if $POS is comment."
   (or $pos (setq $pos (point)))
   (nth 4 (parse-partial-sexp (point-min) $pos)))
 
 (defun helm-css-scss-selector-to-hash ()
-  "Collect all selectors and make hash table"
+  "Collect all selectors and make hash table."
   (let ($selector $paren-beg $paren-end $hash $dep $max $sl
                   $selector-name $selector-beg $selector-end
                   $selector-line)
@@ -330,7 +336,7 @@ This function needs to call after latest helm-css-scss-overlay set."
     $hash))
 
 (defun helm-css-scss-selector-hash-to-list ()
-  "Collected selector hash table to list"
+  "Collected selector hash table to list."
   (let (($hash (helm-css-scss-selector-to-hash)))
     (loop for $k being hash-key in $hash using (hash-values $v)
           collect (cons $k $v))))
@@ -453,6 +459,7 @@ If $noexcursion is not-nil cursor doesn't move."
                       (insert (format " /*__ %s */" $sel)))))))
 
 (defun helm-css-scss-current-selector (&optional $list $pos)
+  "Current selector."
   (interactive)
   "Return selector that $pos is in"
   (unless $list (setq $list (helm-css-scss-selector-hash-to-list)))
@@ -469,38 +476,43 @@ If $noexcursion is not-nil cursor doesn't move."
 
 ;;;###autoload
 (defun helm-css-scss-move-and-echo-next-selector ()
+  "Move and echo next selector."
   (interactive)
   (let ($s)
     (message (if (setq $s (car (helm-css-scss-selector-next)))
-               $s
-             (goto-char (point-max))
-             "No more exist the next target from here"))))
+                 $s
+               (goto-char (point-max))
+               "No more exist the next target from here"))))
 
 ;;;###autoload
 (defun helm-css-scss-move-and-echo-previous-selector ()
+  "Move and echo previous selector."
   (interactive)
   (let ($s)
     (message (if (setq $s (car (helm-css-scss-selector-previous)))
-               $s
-             (goto-char (point-min))
-             "No more exist the previous target from here"))))
+                 $s
+               (goto-char (point-min))
+               "No more exist the previous target from here"))))
 
 ;;; helm -----------------------------
 
 (defadvice helm-next-line (around helm-css-scss--next-line disable)
+  "Advice for `helm-next-line'."
   (let ((helm-move-to-line-cycle-in-source t))
     ad-do-it
     (when (called-interactively-p 'any)
       (helm-css-scss--synchronizing-position))))
 (defadvice helm-previous-line (around helm-css-scss--previous-line disable)
+  "Advice for `helm-previous-line'."
   (let ((helm-move-to-line-cycle-in-source t))
     ad-do-it
     (when (called-interactively-p 'any)
       (helm-css-scss--synchronizing-position))))
 
 (defvar helm-css-scss-synchronizing-window nil
-  "Store window identity for synchronizing")
+  "Store window identity for synchronizing.")
 (defun helm-css-scss--synchronizing-position ()
+  "Synchronizing position."
   (with-helm-window
     (let* (($key (helm-css-scss--trim-whitespace
                   (buffer-substring-no-properties (point-at-bol) (point-at-eol))))
@@ -517,6 +529,7 @@ If $noexcursion is not-nil cursor doesn't move."
       (setq helm-css-scss-last-line-info (cons $buf (nth 5 $prop))))))
 
 (defun helm-c-source-helm-css-scss ($list)
+  "Helm css scss."
   `((name . ,(buffer-name helm-css-scss-target-buffer))
     (candidates . ,$list)
     (action ("Goto open brace"  . (lambda ($pos)
@@ -527,6 +540,7 @@ If $noexcursion is not-nil cursor doesn't move."
     (keymap . ,helm-css-scss-map)))
 
 (defun helm-css-scss-back-to-last-point (&optional $cancel)
+  "Back to last point."
   (interactive)
   "Go back to last position where `helm-css-scss' was called"
   (if helm-css-scss-last-point
@@ -538,12 +552,12 @@ If $noexcursion is not-nil cursor doesn't move."
                 (cons $po (buffer-name (current-buffer))))))))
 
 (defun helm-css-scss--clear-cache ()
-  "Clear cache when buffer saved"
+  "Clear cache when buffer saved."
   (if (boundp 'helm-css-scss-cache) (setq helm-css-scss-cache nil)))
 (add-hook 'after-save-hook 'helm-css-scss--clear-cache)
 
 (defun helm-css-scss--set ()
-  "Override helm's default behavior for helm-css-scss"
+  "Override helm's default behavior for helm-css-scss."
   (setq helm-css-scss-synchronizing-window (selected-window))
   (setq helm-css-scss-last-point (cons (point) (buffer-name (current-buffer))))
   (setq helm-css-scss-target-buffer (current-buffer))
@@ -553,7 +567,7 @@ If $noexcursion is not-nil cursor doesn't move."
     (set (make-local-variable 'helm-css-scss-last-query) "")))
 
 (defun helm-css-scss--restore ()
-  "Restore helm's hook and window function"
+  "Restore helm's hook and window function."
   (when (= 1 helm-exit-status)
     (helm-css-scss-back-to-last-point t)
     (helm-css-scss--restore-unveiled-overlay))
@@ -562,6 +576,7 @@ If $noexcursion is not-nil cursor doesn't move."
 
 ;;;###autoload
 (defun helm-css-scss (&optional $query)
+  "CSS/SCSS/LESS coding faster and easier than ever."
   (interactive)
   (or $query (setq $query ""))
   ;; Cache
@@ -603,6 +618,7 @@ If $noexcursion is not-nil cursor doesn't move."
 ;; multi buffers -----------------------------------------
 
 (defadvice helm-move--next-line-fn (around helm-css-scss--next-line-cycle disable)
+  "Advice for `helm-move--next-line-fn'."
   (if (not (helm-pos-multiline-p))
       (progn (forward-line 1)
              (when (eobp)
@@ -614,6 +630,7 @@ If $noexcursion is not-nil cursor doesn't move."
         (helm-beginning-of-buffer)))))
 (defadvice helm-move--previous-line-fn (around
                                         helm-css-scss--previous-line-cycle disable)
+  "Advice for `helm-move--previous-line-fn'."
   (if (not (helm-pos-multiline-p))
       (forward-line -1)
     (helm-move--previous-multi-line-fn))
@@ -623,17 +640,20 @@ If $noexcursion is not-nil cursor doesn't move."
       (and (helm-pos-multiline-p) (helm-move--previous-multi-line-fn)))))
 
 (defadvice helm-next-line (around helm-css-scss-multi--next-line disable)
+  "Advice for `helm-next-line'."
   (let ((helm-move-to-line-cycle-in-source nil))
     ad-do-it
     (when (called-interactively-p 'any)
       (helm-css-scss--move-line-action))))
 (defadvice helm-previous-line (around helm-css-scss-multi--previous-line disable)
+  "Advice for `helm-previous-line'."
   (let ((helm-move-to-line-cycle-in-source nil))
     ad-do-it
     (when (called-interactively-p 'any)
       (helm-css-scss--move-line-action))))
 
 (defun helm-css-scss--move-line-action ()
+  "Exec move line action."
   (with-helm-window
     (let* (($key (helm-css-scss--trim-whitespace
                   (buffer-substring-no-properties (point-at-bol) (point-at-eol))))
@@ -654,6 +674,7 @@ If $noexcursion is not-nil cursor doesn't move."
       (setq helm-css-scss-last-line-info (cons $buf (nth 5 $prop))))))
 
 (defun helm-css-scss--multi (ignored $query $buffers)
+  "Exec `helm-css-scss' multi."
   (let (($buffs (or $buffers (helm-css-scss--get-buffer-list)))
         $contents
         $preserve-position
@@ -729,7 +750,7 @@ If $noexcursion is not-nil cursor doesn't move."
               $preserve-position)))))
 
 (defun helm-css-scss--get-buffer-list ()
-  "Get all CSS/SCSS/LESS buffers currently open"
+  "Get all CSS/SCSS/LESS buffers currently open."
   (let ($buflist1 $file)
     (mapc (lambda ($buf)
             (setq $file (buffer-file-name $buf))
@@ -740,8 +761,8 @@ If $noexcursion is not-nil cursor doesn't move."
     $buflist1))
 
 (defun helm-css-scss-multi (&optional $query)
+  "Apply all CSS/SCSS/LESS buffers."
   (interactive)
-  "Apply all CSS/SCSS/LESS buffers"
   (if $query
       (setq helm-css-scss-last-query $query)
     (setq helm-css-scss-last-query ""))
@@ -750,7 +771,7 @@ If $noexcursion is not-nil cursor doesn't move."
                         (helm-css-scss--get-buffer-list)))
 
 (defun helm-css-scss-from-isearch ()
-"Invoke `helm-css-scss-multi' from isearch."
+  "Invoke `helm-css-scss-multi' from isearch."
   (interactive)
   (let (($input (if isearch-regexp
                     isearch-string
@@ -774,7 +795,7 @@ If $noexcursion is not-nil cursor doesn't move."
 
 ;; For helm-resum ---------------------------------
 (defadvice helm-resume (around helm-css-scss-resume activate)
-  "Resume if the last used helm buffer is helm-css-scss-buffer"
+  "Resume if the last used helm buffer is helm-css-scss-buffer."
   (if (equal helm-last-buffer helm-css-scss-buffer)
       (if (boundp 'helm-css-scss-last-query)
           (if (not (ad-get-arg 0))
@@ -784,7 +805,7 @@ If $noexcursion is not-nil cursor doesn't move."
     ad-do-it))
 
 (defadvice helm-resume (around helm-css-scss-multi-resume activate)
-  "Resume if the last used helm buffer is helm-css-scss-multi-buffer"
+  "Resume if the last used helm buffer is helm-css-scss-multi-buffer."
   (if (equal helm-last-buffer helm-css-scss-multi-buffer)
       (if (boundp 'helm-css-scss-last-query)
           (if (not (ad-get-arg 0))


### PR DESCRIPTION
fix package-lint/check-doc/byte-compiler warnings

### before

``` emacs-lisp
 helm-css…     9   4 warning         You should include standard keywords: see the variable `finder-known-keywords'. (emacs-lisp-package)
 helm-css…    37     warning         There should be two spaces after a period (emacs-lisp-checkdoc)
 helm-css…    58     warning         There should be two spaces after a period (emacs-lisp-checkdoc)
 helm-css…    64  30 warning         Replace deprecated `cl' with `cl-lib'.  The `cl-libify' package can help with this. (emacs-lisp-package)
 helm-css…    66   1 error           Cannot open load file: No such file or directory, helm (emacs-lisp)
 helm-css…    75     warning         First sentence should end with punctuation (emacs-lisp-checkdoc)
 helm-css…    80     warning         First sentence should end with punctuation (emacs-lisp-checkdoc)
 helm-css…    85     warning         First sentence should end with punctuation (emacs-lisp-checkdoc)
 helm-cs…    91     warning         First sentence should end with punctuation (emacs-lisp-checkdoc)
 helm-cs…   149     warning         First sentence should end with punctuation (emacs-lisp-checkdoc)
 helm-cs…   157     warning         First sentence should end with punctuation (emacs-lisp-checkdoc)
 helm-cs…   171     warning         First sentence should end with punctuation (emacs-lisp-checkdoc)
 helm-cs…   171     warning         Argument ‘$beg’ should appear (as $BEG) in the doc string (emacs-lisp-checkdoc)
 helm-cs…   176     warning         First sentence should end with punctuation (emacs-lisp-checkdoc)
 helm-cs…   176     warning         Argument ‘$i’ should appear (as $I) in the doc string (emacs-lisp-checkdoc)
 helm-cs…   182     warning         First sentence should end with punctuation (emacs-lisp-checkdoc)
 helm-cs…   182     warning         Argument ‘$text’ should appear (as $TEXT) in the doc string (emacs-lisp-checkdoc)
 helm-cs…   188     warning         First sentence should end with punctuation (emacs-lisp-checkdoc)
 helm-cs…   188     warning         Argument ‘$str’ should appear (as $STR) in the doc string (emacs-lisp-checkdoc)
 helm-cs…   194     warning         All variables and subroutines might as well have a documentation string (emacs-lisp-checkdoc)
 helm-cs…   198     warning         All variables and subroutines might as well have a documentation string (emacs-lisp-checkdoc)
 helm-cs…   204     warning         All variables and subroutines might as well have a documentation string (emacs-lisp-checkdoc)
 helm-cs…   223     warning         All variables and subroutines might as well have a documentation string (emacs-lisp-checkdoc)
 helm-cs…   226     warning         Argument ‘$target’ should appear (as $TARGET) in the doc string (emacs-lisp-checkdoc)
 helm-cs…   229   8 error           You should depend on (emacs "24.3") or the cl-lib package if you need `cl-labels'. (emacs-lisp-package)
 helm-cs…   256     warning         All variables and subroutines might as well have a documentation string (emacs-lisp-checkdoc)
 helm-cs…   289     warning         All variables and subroutines might as well have a documentation string (emacs-lisp-checkdoc)
 helm-cs…   293     warning         First sentence should end with punctuation (emacs-lisp-checkdoc)
 helm-cs…   310  11 error           You should depend on (emacs "24.3") or the cl-lib package if you need `cl-case'. (emacs-lisp-package)
 helm-cs…   333     warning         First sentence should end with punctuation (emacs-lisp-checkdoc)
 helm-cs…   456     warning         All interactive functions should have documentation (emacs-lisp-checkdoc)
 helm-cs…   472     warning         All interactive functions should have documentation (emacs-lisp-checkdoc)
 helm-cs…   481     warning         All interactive functions should have documentation (emacs-lisp-checkdoc)
 helm-cs…   491     warning         All variables and subroutines might as well have a documentation string (emacs-lisp-checkdoc)
 helm-cs…   496     warning         All variables and subroutines might as well have a documentation string (emacs-lisp-checkdoc)
 helm-cs…   502     warning         First sentence should end with punctuation (emacs-lisp-checkdoc)
 helm-cs…   504     warning         All variables and subroutines might as well have a documentation string (emacs-lisp-checkdoc)
 helm-cs…   519   1 error           "helm-c-source-helm-css-scss" doesn't start with package's prefix "helm-css-scss". (emacs-lisp-package)
 helm-cs…   520     warning         All variables and subroutines might as well have a documentation string (emacs-lisp-checkdoc)
 helm-cs…   530     warning         All interactive functions should have documentation (emacs-lisp-checkdoc)
 helm-cs…   541     warning         First sentence should end with punctuation (emacs-lisp-checkdoc)
 helm-cs…   546     warning         First sentence should end with punctuation (emacs-lisp-checkdoc)
 helm-cs…   556     warning         First sentence should end with punctuation (emacs-lisp-checkdoc)
 helm-cs…   565     warning         All interactive functions should have documentation (emacs-lisp-checkdoc)
 helm-cs…   606     warning         All variables and subroutines might as well have a documentation string (emacs-lisp-checkdoc)
 helm-cs…   617     warning         All variables and subroutines might as well have a documentation string (emacs-lisp-checkdoc)
 helm-cs…   626     warning         All variables and subroutines might as well have a documentation string (emacs-lisp-checkdoc)
 helm-cs…   631     warning         All variables and subroutines might as well have a documentation string (emacs-lisp-checkdoc)
 helm-cs…   637     warning         All variables and subroutines might as well have a documentation string (emacs-lisp-checkdoc)
 helm-cs…   657     warning         All variables and subroutines might as well have a documentation string (emacs-lisp-checkdoc)
 helm-cs…   732     warning         First sentence should end with punctuation (emacs-lisp-checkdoc)
 helm-cs…   743     warning         All interactive functions should have documentation (emacs-lisp-checkdoc)
 helm-cs…   777     warning         First sentence should end with punctuation (emacs-lisp-checkdoc)
 helm-cs…   787     warning         First sentence should end with punctuation (emacs-lisp-checkdoc)
```


### after

``` emacs-lisp
 helm-css…    64  30 warning         Replace deprecated `cl' with `cl-lib'.  The `cl-libify' package can help with this. (emacs-lisp-package)
 helm-cs…    66   1 error           Cannot open load file: No such file or directory, helm (emacs-lisp)
 helm-cs…   171     warning         Argument ‘$beg’ should appear (as $BEG) in the doc string (emacs-lisp-checkdoc)
 helm-cs…   176     warning         Argument ‘$i’ should appear (as $I) in the doc string (emacs-lisp-checkdoc)
 helm-cs…   182     warning         Argument ‘$text’ should appear (as $TEXT) in the doc string (emacs-lisp-checkdoc)
 helm-cs…   188     warning         Argument ‘$str’ should appear (as $STR) in the doc string (emacs-lisp-checkdoc)
 helm-cs…   194     warning         Argument ‘$line’ should appear (as $LINE) in the doc string (emacs-lisp-checkdoc)
 helm-cs…   199     warning         Argument ‘$regexp’ should appear (as $REGEXP) in the doc string (emacs-lisp-checkdoc)
 helm-cs…   199     warning         Probably "matches" should be imperative "match" (emacs-lisp-checkdoc)
 helm-cs…   230     warning         Argument ‘$target’ should appear (as $TARGET) in the doc string (emacs-lisp-checkdoc)
 helm-cs…   294     warning         Argument ‘$pos’ should appear (as $POS) in the doc string (emacs-lisp-checkdoc)
 helm-cs…   462     warning         Argument ‘$list’ should appear (as $LIST) in the doc string (emacs-lisp-checkdoc)
 helm-cs…   531   1 error           "helm-c-source-helm-css-scss" doesn't start with package's prefix "helm-css-scss". (emacs-lisp-package)
 helm-cs…   532     warning         Argument ‘$list’ should appear (as $LIST) in the doc string (emacs-lisp-checkdoc)
 helm-cs…   543     warning         Argument ‘$cancel’ should appear (as $CANCEL) in the doc string (emacs-lisp-checkdoc)
 helm-cs…   579     warning         Argument ‘$query’ should appear (as $QUERY) in the doc string (emacs-lisp-checkdoc)
 helm-cs…   677     warning         Argument ‘ignored’ should appear (as IGNORED) in the doc string (emacs-lisp-checkdoc)
 helm-cs…   764     warning         Argument ‘$query’ should appear (as $QUERY) in the doc string (emacs-lisp-checkdoc)
```